### PR TITLE
Fixing CGAL cmake module

### DIFF
--- a/cmake/Modules/FindCGAL.cmake
+++ b/cmake/Modules/FindCGAL.cmake
@@ -20,7 +20,7 @@ include( SimplePackageFind )
 set( PACKAGE_NAME           CGAL )
 set( PACKAGE_DIRS           CGAL )
 set( PACKAGE_REQ_LIBRARY    CGAL )
-set( PACKAGE_REQ_INCLUDE    CGAL/CGALversion.h )
+set( PACKAGE_REQ_INCLUDE    CGAL/version.h )
 
 simple_package_find("${PACKAGE_NAME}" 
                    "${PACKAGE_DIRS}" 


### PR DESCRIPTION
The FindCGAL.cmake was breaking the Astrobee repo.  

Small typo fix.
