### PR TITLE
Ubuntu 16.04 and 14.04 compatibility

### DIFF
--- a/kn/src/knMath/ATrans.cpp
+++ b/kn/src/knMath/ATrans.cpp
@@ -27,7 +27,7 @@ namespace kn
 
   std::ostream& operator<< (std::ostream& ostr, ATrans2Out const& rhs)
   {
-    Eigen::Rotation2Dd theta;
+    Eigen::Rotation2Dd theta(0.);
     theta.fromRotationMatrix(rhs.transform().rotation());
     ostr << "("
          << rhs.transform().translation().x() << ", " << rhs.transform().translation().y()

--- a/kn/src/knMotorShare/WheelGroupFuture.cpp
+++ b/kn/src/knMotorShare/WheelGroupFuture.cpp
@@ -25,7 +25,7 @@ namespace kn
 {
   std::ostream& operator<< (std::ostream& ostr, WheelGroupFuture const& rhs)
   {
-    Eigen::Rotation2Dd theta;
+    Eigen::Rotation2Dd theta(0.);
     theta.fromRotationMatrix(rhs.offset.rotation());
     ostr << "{";
     ostr << static_cast<WheelGroupState const&>(rhs);

--- a/knRapid/src/rapidTools/genericCommandGui/CommandConfigSubscriber.h
+++ b/knRapid/src/rapidTools/genericCommandGui/CommandConfigSubscriber.h
@@ -21,7 +21,9 @@
 
 #include <QObject>
 
+#ifndef Q_MOC_RUN
 #include "knDds/DdsTypedConnector.h"
+#endif
 
 #include "rapidDds/CommandConfig.h"
 #include "rapidDds/CommandConfigSupport.h"

--- a/knRapid/src/rapidTools/imageSensorSampleGui/ImageSensorSampleSubscriber.h
+++ b/knRapid/src/rapidTools/imageSensorSampleGui/ImageSensorSampleSubscriber.h
@@ -19,7 +19,9 @@
 #include <QObject>
 #include <QPixmap>
 
+#ifndef Q_MOC_RUN
 #include "knDds/DdsTypedConnector.h"
+#endif
 
 #include "rapidDds/ImageSensorSample.h"
 #include "rapidDds/ImageSensorSampleSupport.h"


### PR DESCRIPTION
Use zero-initializer syntax compatible with Eigen versions in both Ubuntu 16.04 and 14.04. Also block some headers from MOC step so that Qt version in Ubuntu 16.04 doesn't fail with obscure Boost errors.